### PR TITLE
Allow the scanner to recover from a 404 response from TA

### DIFF
--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -577,9 +577,10 @@ def Scan(path, files, mediaList, subdirs):  # noqa: C901
                                 episode = video_metadata["episode"]
                             except Exception as e:
                                 Log.error(
-                                    "Issue with setting metadata from video using response metadata: '%s', Exception: '%s'"  # noqa: E501
+                                    "Issue with fetching or setting metadata from video using response metadata: '%s', Exception: '%s'"  # noqa: E501
                                     % (str(video_metadata), e)
                                 )
+                                continue
                         else:
                             Log.error(
                                 "TubeArchivist instance is not accessible or not online. Unable to process video file."  # noqa: E501


### PR DESCRIPTION
I lost my TA database and when rebuilding it from the video files some of the files didn't populate (I assume because they were taken down after I originally downloaded them). Since the files still exist the scanner finds them and tries to query TA for the metadata, but receives a 404 and the script isn't allowed to continue. This fix continues the loop so that rest of the  videos can be pulled in.