### PR TITLE
v0.1.8 fixes to work with TA v0.5.3 formatting changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ If the Scanner and Agent are selected, but you are not seeing videos, then it co
 If the Scanner and Agent are selected, but the channels or videos are not pulling in thumbnails, correct titles, or having other issues with the metadata, then it could mean that the Agent is having a problem. Check the Agent Logs to get more information.
 Reminder: If using a non-standard port (HTTP uses 80, HTTPS uses 443), including the TubeArchivist default port of 8000, that must be included with the `TA_URL` configurations.
 
-Local subtitles that are provided outside of the TubeArchivist context are not typically supported, but you can still access them via the [Local Assets configuration in the Agent Settings for Metadata Agents](https://support.plex.tv/articles/200241558-agents/).
+If you have a firewall or Cloudflare proxy, this can block all requests and report back as `HTTP 403: Forbidden`. If you are seeing these, first check that you have the correct `TA_URL`, that the `TA_URL` matches your TubeArchivist `TA_HOST`, then check if your firewall settings. [Issue 32](https://github.com/tubearchivist/tubearchivist-plex/issues/32) has more details for the Cloudflare Firewall and Bot Protection features.
+
+Local subtitles that are provided outside of the TubeArchivist context are not typically supported, but you can still access them via the [Local Media Assets configuration in the Agent Settings for Metadata Agents](https://support.plex.tv/articles/200241558-agents/). Sometimes you will also need to enable the Local Media Assets if subtitles are not showing from TubeArchivist.
 
 # Log Locations
 Scanner Log Location: `Plex Media Server/Logs/TubeArchivist Scanner`, default file is `_root_.scanner.log`

--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ A list of potential default installation locations:
 # Troubleshooting
 If you are having problems with seeing the Scanner or Agent, confirm that the instructions are followed.
 If the Scanner and Agent are selected, but you are not seeing videos, then it could mean that the Scanner is having a problem. Check the Scanner Logs to get more information.
+
 If the Scanner and Agent are selected, but the channels or videos are not pulling in thumbnails, correct titles, or having other issues with the metadata, then it could mean that the Agent is having a problem. Check the Agent Logs to get more information.
 Reminder: If using a non-standard port (HTTP uses 80, HTTPS uses 443), including the TubeArchivist default port of 8000, that must be included with the `TA_URL` configurations.
+
+Local subtitles that are provided outside of the TubeArchivist context are not typically supported, but you can still access them via the [Local Assets configuration in the Agent Settings for Metadata Agents](https://support.plex.tv/articles/200241558-agents/).
 
 # Log Locations
 Scanner Log Location: `Plex Media Server/Logs/TubeArchivist Scanner`, default file is `_root_.scanner.log`

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -471,15 +471,24 @@ def get_ta_video_metadata(ytid):
                 video_refresh = datetime.datetime.strptime(
                     vid_response["vid_last_refresh"], "%d %b, %Y"
                 )
-            else:
+            elif TA_CONFIG["version"] < [0, 5, 3]:
                 metadata["processed_date"] = datetime.datetime.strptime(
                     vid_response["published"], "%Y-%m-%d"
                 )
                 video_refresh = datetime.datetime.strptime(
                     vid_response["vid_last_refresh"], "%Y-%m-%d"
                 )
+            else:
+                metadata["processed_date"] = datetime.datetime.strptime(
+                    vid_response["published"], "%Y-%m-%dT%H:%M:%S%z"
+                )
+                video_refresh = datetime.datetime.strptime(
+                    vid_response["vid_last_refresh"], "%Y-%m-%dT%H:%M:%S%z"
+                )
+            # With the additional metadata, we can be more specific with the season ordering for v0.2.0 # noqa: E501
             metadata["refresh_date"] = video_refresh.strftime("%Y%m%d")
             metadata["season"] = metadata["processed_date"].year
+            # With the additional metadata, we can be more specific with the season ordering for v0.2.0 # noqa: E501
             metadata["episode"] = metadata["processed_date"].strftime("%Y%m%d")
             metadata["description"] = vid_response["description"]
             metadata["thumb_url"] = vid_response["vid_thumb_url"]
@@ -536,9 +545,13 @@ def get_ta_channel_metadata(chid):
                 channel_refresh = datetime.datetime.strptime(
                     ch_response["channel_last_refresh"], "%d %b, %Y"
                 )
-            else:
+            elif TA_CONFIG["version"] < [0, 5, 3]:
                 channel_refresh = datetime.datetime.strptime(
                     ch_response["channel_last_refresh"], "%Y-%m-%d"
+                )
+            else:
+                channel_refresh = datetime.datetime.strptime(
+                    ch_response["channel_last_refresh"], "%Y-%m-%dT%H:%M:%S%z"
                 )
             metadata["refresh_date"] = channel_refresh.strftime("%Y%m%d")
             metadata["description"] = ch_response["channel_description"]

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -102,7 +102,7 @@ def setup():
         )
         Log.debug("Plex Python environment: ")
         Log.debug("\tPython version: %s" % (sys.version))
-        Log.debug("\tPython argv: %s" % (sys.argv))
+        # Log.debug("\tPython argv: %s" % (sys.argv))
         Log.debug("\tPython platform: %s" % (sys.platform))
         Log.debug("\tPython prefix: %s" % (sys.prefix))
         # Log.debug("\tPython thread info: %s" % (sys.thread_info))

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -100,7 +100,6 @@ def setup():
                 datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")
             )
         )
-        Log.debug()
         SetupDone = True
         return True
 

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -480,6 +480,19 @@ def get_ta_video_metadata(ytid):
                 )
             else:
                 Log.debug("Published Date: %s" % (vid_response["published"]))
+                Log.debug(
+                    "Published Date (revised): %s"
+                    % ("".join(vid_response["published"].rsplit(":", 1)))
+                )
+                Log.debug(
+                    "Published Date (without timezone)"
+                    % (
+                        datetime.datetime.strptime(
+                            "".join(vid_response["published"].rsplit(":", 1)),
+                            "%Y-%m-%dT%H:%M:%S",
+                        )
+                    )
+                )
                 metadata["processed_date"] = datetime.datetime.strptime(
                     "".join(vid_response["published"].rsplit(":", 1)),
                     "%Y-%m-%dT%H:%M:%S%z",

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -105,7 +105,7 @@ def setup():
         Log.debug("\tPython argv: %s" % (sys.argv))
         Log.debug("\tPython platform: %s" % (sys.platform))
         Log.debug("\tPython prefix: %s" % (sys.prefix))
-        Log.debug("\tPython thread info: %s" % (sys.thread_info))
+        # Log.debug("\tPython thread info: %s" % (sys.thread_info))
         SetupDone = True
         return True
 

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -479,9 +479,14 @@ def get_ta_video_metadata(ytid):
                     vid_response["vid_last_refresh"], "%Y-%m-%d"
                 )
             else:
+                Log.debug("Published Date: %s" % (vid_response["published"]))
                 metadata["processed_date"] = datetime.datetime.strptime(
                     "".join(vid_response["published"].rsplit(":", 1)),
                     "%Y-%m-%dT%H:%M:%S%z",
+                )
+                Log.debug(
+                    "Last Refresh Date: %s"
+                    % (vid_response["vid_last_refresh"])
                 )
                 video_refresh = datetime.datetime.strptime(
                     "".join(vid_response["vid_last_refresh"].rsplit(":", 1)),

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -100,6 +100,7 @@ def setup():
                 datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")
             )
         )
+        Log.debug()
         SetupDone = True
         return True
 
@@ -480,10 +481,12 @@ def get_ta_video_metadata(ytid):
                 )
             else:
                 metadata["processed_date"] = datetime.datetime.strptime(
-                    vid_response["published"], "%Y-%m-%dT%H:%M:%S%z"
+                    "".join(vid_response["published"].rsplit(":", 1)),
+                    "%Y-%m-%dT%H:%M:%S%z",
                 )
                 video_refresh = datetime.datetime.strptime(
-                    vid_response["vid_last_refresh"], "%Y-%m-%dT%H:%M:%S%z"
+                    "".join(vid_response["vid_last_refresh"].rsplit(":", 1)),
+                    "%Y-%m-%dT%H:%M:%S%z",
                 )
             # With the additional metadata, we can be more specific with the season ordering for v0.2.0 # noqa: E501
             metadata["refresh_date"] = video_refresh.strftime("%Y%m%d")
@@ -551,7 +554,10 @@ def get_ta_channel_metadata(chid):
                 )
             else:
                 channel_refresh = datetime.datetime.strptime(
-                    ch_response["channel_last_refresh"], "%Y-%m-%dT%H:%M:%S%z"
+                    "".join(
+                        ch_response["channel_last_refresh"].rsplit(":", 1)
+                    ),
+                    "%Y-%m-%dT%H:%M:%S%z",
                 )
             metadata["refresh_date"] = channel_refresh.strftime("%Y%m%d")
             metadata["description"] = ch_response["channel_description"]

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -100,6 +100,12 @@ def setup():
                 datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")
             )
         )
+        Log.debug("Plex Python environment: ")
+        Log.debug("\tPython version: %s" % (sys.version))
+        Log.debug("\tPython argv: %s" % (sys.argv))
+        Log.debug("\tPython platform: %s" % (sys.platform))
+        Log.debug("\tPython prefix: %s" % (sys.prefix))
+        Log.debug("\tPython thread info: %s" % (sys.thread_info))
         SetupDone = True
         return True
 


### PR DESCRIPTION
Resolves TA v0.5.3 formatting changes to datetime objects (now storing in ISO 8601 format).
Additional updates to README to cover requests.

Resolves #97, #101, and #103.