### PR TITLE
enhancement to response["version"] interpretation

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -402,9 +402,7 @@ def check_ta_version_in_response(response):
                 # This handles cases where response["version"] is not a string 
                 # (e.g., if it's already a list or a number)
                 ta_version = response["version"]
-            
-            # The Log.Info section remains the same
-            Log.Info(  # type: ignore # noqa: F821
+            Log.info(
                 "TubeArchivist is running version v{}".format(
                     ".".join(str(x) for x in ta_version)
                 )

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -380,22 +380,30 @@ def check_ta_version_in_response(response):
     try:
         if "version" in response:
             try:
-                if "v" in response["version"]:
+                version_string = response["version"]
+                
+                # Split the string at the first hyphen and take the first part
+                # This removes '-unstable', '-beta', '-rc1', or any other suffix
+                cleaned_version_string = version_string.split('-', 1)[0]
+
+                if cleaned_version_string.startswith("v"):
                     ta_version = [
                         int(x)
-                        for x in response["version"][1:]
-                        .rstrip("-unstable")
+                        for x in cleaned_version_string[1:]
                         .split(".")
                     ]
                 else:
                     ta_version = [
                         int(x)
-                        for x in response["version"]
-                        .rstrip("-unstable")
+                        for x in cleaned_version_string
                         .split(".")
                     ]
             except (AttributeError, TypeError):
+                # This handles cases where response["version"] is not a string 
+                # (e.g., if it's already a list or a number)
                 ta_version = response["version"]
+            
+            # The Log.Info section remains the same
             Log.Info(  # type: ignore # noqa: F821
                 "TubeArchivist is running version v{}".format(
                     ".".join(str(x) for x in ta_version)

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -338,23 +338,31 @@ def check_ta_version_in_response(response):
     try:
         if "version" in response:
             try:
-                if "v" in response["version"]:
+                version_string = response["version"]
+                
+                # Split the string at the first hyphen and take the first part
+                # This removes '-unstable', '-beta', '-rc1', or any other suffix
+                cleaned_version_string = version_string.split('-', 1)[0]
+
+                if cleaned_version_string.startswith("v"):
                     ta_version = [
                         int(x)
-                        for x in response["version"][1:]
-                        .rstrip("-unstable")
+                        for x in cleaned_version_string[1:]
                         .split(".")
                     ]
                 else:
                     ta_version = [
                         int(x)
-                        for x in response["version"]
-                        .rstrip("-unstable")
+                        for x in cleaned_version_string
                         .split(".")
                     ]
             except (AttributeError, TypeError):
+                # This handles cases where response["version"] is not a string 
+                # (e.g., if it's already a list or a number)
                 ta_version = response["version"]
-            Log.info(
+            
+            # The Log.Info section remains the same
+            Log.Info(  # type: ignore # noqa: F821
                 "TubeArchivist is running version v{}".format(
                     ".".join(str(x) for x in ta_version)
                 )

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -360,9 +360,7 @@ def check_ta_version_in_response(response):
                 # This handles cases where response["version"] is not a string 
                 # (e.g., if it's already a list or a number)
                 ta_version = response["version"]
-            
-            # The Log.Info section remains the same
-            Log.Info(  # type: ignore # noqa: F821
+            Log.info(
                 "TubeArchivist is running version v{}".format(
                     ".".join(str(x) for x in ta_version)
                 )


### PR DESCRIPTION
I had modified my locally running tubearchivist and therefore changed the version string using word other than "unstable" after.
This prevented tubearchivist-plex from functioning.
Since the existing logic discards the text after the hyphen I improved the logic to discard anything after the hyphen.

```
# Split the string at the first hyphen and take the first part
# This removes '-unstable', '-beta', '-rc1', or any other suffix
```