### PR TITLE
Parse language code - extract base language from locale

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -580,7 +580,15 @@ def PullTASubtitles(vid_metadata, filepath, media_obj):  # noqa: C901
         if ext in [".vtt"]:
             codec = "vtt"
             format = None
-            lang_match = Locale.Language.Match(sub["lang"])  # type: ignore # noqa: F821, E501
+
+            # Parse language code - extract base language from locale
+            # (e.g., "en" from "en-US")
+            lang_code = sub["lang"]
+            if "-" in lang_code:
+                base_lang = lang_code.split("-")[0]
+                lang_code = base_lang
+
+            lang_match = Locale.Language.Match(lang_code)  # type: ignore # noqa: F821, E501
 
             if os.path.exists(filepath):
                 filename = os.path.basename(sub["media_url"])


### PR DESCRIPTION
In my specific use case, I had subtitles from Youtube that had a language code of `en-US`.
The tubearchivist-plex code utilizes the PMS Extension Framework which requires the language code to be 2 characters.
I added logic that if the language code from the subtitles contains a hyphen to only pass the first half on to the Framework.