### PR TITLE
Add Playlist Support with Subscription-Aware Organization

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,0 +1,40 @@
+---
+when:
+  event: tag
+
+steps:
+  - name: build-release
+    image: alpine:latest
+    commands:
+      - apk add --no-cache tar
+      - |
+        # Create release tarball with scanner and agent
+        mkdir -p release/Scanners/Series
+        mkdir -p release/Plug-ins
+        
+        cp -r Scanners/Series/* release/Scanners/Series/
+        cp -r . release/Plug-ins/TubeArchivist-Agent.bundle
+        
+        # Clean up git files from agent bundle
+        rm -rf release/Plug-ins/TubeArchivist-Agent.bundle/.git
+        rm -rf release/Plug-ins/TubeArchivist-Agent.bundle/.github
+        rm -f release/Plug-ins/TubeArchivist-Agent.bundle/.woodpecker.yml
+        
+        # Create tarball
+        cd release
+        tar -czf ../tubearchivist-plex-${CI_COMMIT_TAG}.tar.gz .
+        cd ..
+        
+        echo "Release artifact: tubearchivist-plex-${CI_COMMIT_TAG}.tar.gz"
+        ls -lh tubearchivist-plex-${CI_COMMIT_TAG}.tar.gz
+
+  - name: publish-release
+    image: plugins/gitea-release
+    settings:
+      api_key:
+        from_secret: gitea_token
+      base_url: https://git.silverhollow.xyz
+      files:
+        - "tubearchivist-plex-*.tar.gz"
+      title: "Release ${CI_COMMIT_TAG}"
+      note: "TubeArchivist Plex plugin release ${CI_COMMIT_TAG}"

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -564,6 +564,57 @@ def get_ta_channel_metadata(chid):
         raise e
 
 
+def get_ta_playlist_metadata(plid):
+    mtype = "playlist"
+    if not TA_CONFIG:
+        Log.Error("No configurations in TA_CONFIG.")  # type: ignore # noqa: F821, E501
+        return {}
+    if not plid:
+        Log.Error("No {} ID present.".format(mtype))  # type: ignore # noqa: F821, E501
+        return {}
+    try:
+        pl_response = get_ta_metadata(plid, mtype="playlist")
+        Log.Info(  # type: ignore # noqa: F821
+            "Response from TubeArchivist received for YouTube {}: {}".format(
+                mtype, plid
+            )
+        )
+        if pl_response:
+            if TA_CONFIG["version"] < [0, 5, 0]:
+                pl_response = pl_response["data"]
+            metadata = {}
+            if Prefs["show_channel_id"]:  # type: ignore # noqa: F821
+                metadata["show"] = "{} [{}]".format(
+                    pl_response["playlist_name"],
+                    pl_response["playlist_id"],
+                )
+            else:
+                metadata["show"] = "{}".format(pl_response["playlist_name"])
+            playlist_refresh = Datetime.ParseDate(  # type: ignore # noqa: F821
+                pl_response["playlist_last_refresh"]
+            )
+            metadata["refresh_date"] = playlist_refresh.strftime("%Y%m%d")
+            metadata["description"] = "{}\n\nPlaylist ID: {}".format(
+                pl_response["playlist_description"],
+                pl_response["playlist_id"],
+            )
+            metadata["thumb_url"] = pl_response["playlist_thumbnail"]
+            metadata["playlist_channel"] = pl_response["playlist_channel"]
+            metadata["playlist_channel_id"] = pl_response["playlist_channel_id"]
+            return metadata
+        else:
+            Log.Error(  # type: ignore # noqa: F821
+                "Empty response returned from %s when requesting data about %s."  # noqa: E501
+                % (TA_CONFIG["ta_url"], mtype)
+            )
+    except Exception as e:
+        Log.Error(  # type: ignore # noqa: F821
+            "Error processing %s response from TubeArchivist at location '%s', Exception: '%s'"  # noqa: E501
+            % (mtype, TA_CONFIG["ta_url"], e)
+        )
+        raise e
+
+
 def PullTASubtitles(vid_metadata, filepath, media_obj):  # noqa: C901
     lang_sub_map = {}
     lang_pub_map = []
@@ -753,11 +804,17 @@ def Search(results, media, lang, manual):
                     displayname.rindex("]")
                 )  # noqa: E203
             ]
+            # For playlists, use consistent ID across all folders
+            # For channels, keep folder-specific ID
+            if guid.startswith("PL"):
+                show_id = "tubearchivist|{}|playlist".format(guid)
+            else:
+                show_id = "tubearchivist|{}|{}".format(
+                    guid, os.path.basename(dir)
+                )
             results.Append(
                 MetadataSearchResult(  # type: ignore # noqa: F821
-                    id="tubearchivist|{}|{}".format(
-                        guid, os.path.basename(dir)
-                    ),
+                    id=show_id,
                     name=displayname,
                     year=media.year,
                     score=100,
@@ -801,38 +858,46 @@ def Update(metadata, media, lang, force):  # noqa: C901
     _, guid, _ = metadata.id.split("|")  # Agent | GUID | Series Folder
     if not media:
         Log.Debug(  # type: ignore # noqa: F821
-            "Issue found with Plex while generating media object. Media object not present for agent handling. Agent will only update the channel metadata."  # noqa: E501
+            "Issue found with Plex while generating media object. Media object not present for agent handling. Agent will only update the show metadata."  # noqa: E501
         )
-    channel_id = guid
-    channel_title = ""
-    ch_metadata = {}
+
+    # Detect if GUID is a playlist or channel
+    is_playlist = guid.startswith("PL")
+    show_metadata = {}
+    show_title = ""
 
     if TA_CONFIG["online"]:
         try:
-            ch_metadata = get_ta_channel_metadata(channel_id)
-            channel_title = ch_metadata["show"]
+            if is_playlist:
+                Log.Info("Detected playlist GUID: {}".format(guid))  # type: ignore # noqa: F821, E501
+                show_metadata = get_ta_playlist_metadata(guid)
+                show_title = show_metadata["show"]
+            else:
+                Log.Info("Detected channel GUID: {}".format(guid))  # type: ignore # noqa: F821, E501
+                show_metadata = get_ta_channel_metadata(guid)
+                show_title = show_metadata["show"]
         except AttributeError:
             Log.Critical(  # type: ignore # noqa: F821
-                "Channel not found for item.\nGUID presented: {}\nMetadata Response: {}".format(  # noqa: E501
-                    channel_id, ch_metadata
+                "Show not found for item.\nGUID presented: {}\nMetadata Response: {}".format(  # noqa: E501
+                    guid, show_metadata
                 )
             )
             return 0
     else:
-        channel_title = metadata.title
+        show_title = metadata.title
 
-    metadata.title = channel_title
+    metadata.title = show_title
 
     if TA_CONFIG["online"]:
-        thumb_channel = "{}_{}".format(
-            ch_metadata["refresh_date"], ch_metadata["thumb_url"]
+        thumb_show = "{}_{}".format(
+            show_metadata["refresh_date"], show_metadata["thumb_url"]
         )
-        if thumb_channel and thumb_channel not in metadata.posters:
-            metadata.posters[thumb_channel] = Proxy.Media(  # type: ignore # noqa: F821, E501
+        if thumb_show and thumb_show not in metadata.posters:
+            metadata.posters[thumb_show] = Proxy.Media(  # type: ignore # noqa: F821, E501
                 read_url(
                     Request(
                         "{}{}".format(
-                            TA_CONFIG["ta_url"], ch_metadata["thumb_url"]
+                            TA_CONFIG["ta_url"], show_metadata["thumb_url"]
                         ),
                         headers={
                             "Authorization": "Token {}".format(
@@ -847,22 +912,24 @@ def Update(metadata, media, lang, force):  # noqa: C901
                     else 2
                 ),
             )
-            Log("[X] Posters: {}".format(thumb_channel))  # type: ignore # noqa: F821, E501
-        elif thumb_channel and thumb_channel in metadata.posters:
-            Log("[_] Posters: {}".format(thumb_channel))  # type: ignore # noqa: F821, E501
+            Log("[X] Posters: {}".format(thumb_show))  # type: ignore # noqa: F821, E501
+        elif thumb_show and thumb_show in metadata.posters:
+            Log("[_] Posters: {}".format(thumb_show))  # type: ignore # noqa: F821, E501
         else:
-            Log("[ ] Posters: {}".format(thumb_channel))  # type: ignore # noqa: F821, E501
+            Log("[ ] Posters: {}".format(thumb_show))  # type: ignore # noqa: F821, E501
 
-        tvart_channel = "{}_{}".format(
-            ch_metadata["refresh_date"], ch_metadata["tvart_url"]
-        )
-        if tvart_channel and tvart_channel not in metadata.art:
-            metadata.art[tvart_channel] = Proxy.Media(  # type: ignore # noqa: F821, E501
-                read_url(
-                    Request(
-                        "{}{}".format(
-                            TA_CONFIG["ta_url"], ch_metadata["tvart_url"]
-                        ),
+        # Handle tvart (only for channels, playlists don't have this)
+        if not is_playlist and "tvart_url" in show_metadata:
+            tvart_show = "{}_{}".format(
+                show_metadata["refresh_date"], show_metadata["tvart_url"]
+            )
+            if tvart_show and tvart_show not in metadata.art:
+                metadata.art[tvart_show] = Proxy.Media(  # type: ignore # noqa: F821, E501
+                    read_url(
+                        Request(
+                            "{}{}".format(
+                                TA_CONFIG["ta_url"], show_metadata["tvart_url"]
+                            ),
                         headers={
                             "Authorization": "Token {}".format(
                                 TA_CONFIG["ta_api_key"]
@@ -876,22 +943,24 @@ def Update(metadata, media, lang, force):  # noqa: C901
                     else 2
                 ),
             )
-            Log("[X] Art: {}".format(tvart_channel))  # type: ignore # noqa: F821, E501
-        elif tvart_channel and tvart_channel in metadata.art:
-            Log("[_] Art: {}".format(tvart_channel))  # type: ignore # noqa: F821, E501
-        else:
-            Log("[ ] Art: {}".format(tvart_channel))  # type: ignore # noqa: F821, E501
+                Log("[X] Art: {}".format(tvart_show))  # type: ignore # noqa: F821, E501
+            elif tvart_show and tvart_show in metadata.art:
+                Log("[_] Art: {}".format(tvart_show))  # type: ignore # noqa: F821, E501
+            else:
+                Log("[ ] Art: {}".format(tvart_show))  # type: ignore # noqa: F821, E501
 
-        banner_channel = "{}_{}".format(
-            ch_metadata["refresh_date"], ch_metadata["banner_url"]
-        )
-        if banner_channel and banner_channel not in metadata.banners:
-            metadata.banners[banner_channel] = Proxy.Media(  # type: ignore # noqa: F821, E501
-                read_url(
-                    Request(
-                        "{}{}".format(
-                            TA_CONFIG["ta_url"], ch_metadata["banner_url"]
-                        ),
+        # Handle banner (only for channels, playlists don't have this)
+        if not is_playlist and "banner_url" in show_metadata:
+            banner_show = "{}_{}".format(
+                show_metadata["refresh_date"], show_metadata["banner_url"]
+            )
+            if banner_show and banner_show not in metadata.banners:
+                metadata.banners[banner_show] = Proxy.Media(  # type: ignore # noqa: F821, E501
+                    read_url(
+                        Request(
+                            "{}{}".format(
+                                TA_CONFIG["ta_url"], show_metadata["banner_url"]
+                            ),
                         headers={
                             "Authorization": "Token {}".format(
                                 TA_CONFIG["ta_api_key"]
@@ -905,23 +974,23 @@ def Update(metadata, media, lang, force):  # noqa: C901
                     else 2
                 ),
             )
-            Log("[X] Banners: {}".format(banner_channel))  # type: ignore # noqa: F821, E501
-        elif banner_channel and banner_channel in metadata.banners:
-            Log("[_] Banners: {}".format(banner_channel))  # type: ignore # noqa: F821, E501
-        else:
-            Log("[ ] Banners: {}".format(banner_channel))  # type: ignore # noqa: F821, E501
+                Log("[X] Banners: {}".format(banner_show))  # type: ignore # noqa: F821, E501
+            elif banner_show and banner_show in metadata.banners:
+                Log("[_] Banners: {}".format(banner_show))  # type: ignore # noqa: F821, E501
+            else:
+                Log("[ ] Banners: {}".format(banner_show))  # type: ignore # noqa: F821, E501
 
         metadata.roles.clear()
         role = metadata.roles.new()
-        role.role = channel_title
-        role.name = channel_title
-        role.photo = thumb_channel
+        role.role = show_title
+        role.name = show_title
+        role.photo = thumb_show
 
-        metadata.summary = ch_metadata["description"]
+        metadata.summary = show_metadata["description"]
         metadata.studio = "YouTube"
 
         Log.Info(  # type: ignore # noqa: F821
-            "Channel metadata updates completed for {}.".format(channel_title)
+            "Show metadata updates completed for {}.".format(show_title)
         )
 
         episodes = 0

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The scanner now supports organizing videos by TubeArchivist playlists in additio
 
 The scanner uses a subscription-aware organization system:
 
-1. **Playlist Priority**: If a video belongs to one or more **subscribed playlists** in TubeArchivist, it will appear under those playlist shows in Plex
-2. **Channel Fallback**: If a video is not in any subscribed playlists, it will appear under its channel show (if the channel is subscribed)
-3. **Multi-Playlist Support**: Videos can appear in multiple playlist shows if they belong to multiple subscribed playlists
+1. **Playlist Shows**: Videos that belong to **subscribed playlists** in TubeArchivist will appear under those playlist shows in Plex
+2. **Channel Shows**: Videos from **subscribed channels** in TubeArchivist will appear under their channel show
+3. **Duplicate Entries**: Videos can appear in multiple shows if they belong to multiple subscribed playlists and/or a subscribed channel
 4. **Filtering**: Videos are only shown if they belong to a subscribed playlist OR subscribed channel
 
 ## Setup Requirements
@@ -109,7 +109,9 @@ The scanner uses a subscription-aware organization system:
 
 - Video in subscribed playlist "Best of 2024" → Appears under "Best of 2024" playlist show
 - Video in subscribed channel "Tech Channel" (no playlists) → Appears under "Tech Channel" channel show
+- Video in subscribed playlist + subscribed channel → Appears in BOTH the playlist show and channel show
 - Video in 2 subscribed playlists → Appears in both playlist shows
+- Video in 2 subscribed playlists + subscribed channel → Appears in all 3 shows
 - Video in non-subscribed playlist, non-subscribed channel → Not shown in Plex
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This pulls a lot of the metadata details directly from TubeArchivist, so TubeArc
 
 This is an early build, so there might be issues with detecting certain feature components. Issues with Feature Requests are recommended to document the request, however we may be unable to fulfill all requests without additional help and support. Pull Requests for features to add functionality or fix issues are welcome.
 
-Playlist integration is an expected roadmap item but is not currently available.
+**Playlist integration is now supported!** Videos can be organized by subscribed playlists in addition to channels. See the Playlist Support section below for details.
 
 Not all metadata that Plex can show is being provided at this time and will be incorporate with future releases.
 
@@ -84,6 +84,38 @@ A list of potential default installation locations:
     * TubeArchivist URL: The URL that Plex can access your TubeArchivist instance. Note: If using a non-standard port (HTTP uses 80, HTTPS uses 443), including the TubeArchivist default port of 8000, that must be included with the `TA_URL` configurations.
 6. The Scanner should immediately start finding new videos and update as it sees them, but you can also run a `Scan Library Files` for the Library to initiate a check.
 7. The Agent should update the metadata after finding the new videos, but you can also run a `Refresh Metadata` on the Library, Channel, or individual video to initiate an update.
+
+# Playlist Support
+
+The scanner now supports organizing videos by TubeArchivist playlists in addition to channels. This allows you to group related videos together regardless of which channel they're from.
+
+## How It Works
+
+The scanner uses a subscription-aware organization system:
+
+1. **Playlist Priority**: If a video belongs to one or more **subscribed playlists** in TubeArchivist, it will appear under those playlist shows in Plex
+2. **Channel Fallback**: If a video is not in any subscribed playlists, it will appear under its channel show (if the channel is subscribed)
+3. **Multi-Playlist Support**: Videos can appear in multiple playlist shows if they belong to multiple subscribed playlists
+4. **Filtering**: Videos are only shown if they belong to a subscribed playlist OR subscribed channel
+
+## Setup Requirements
+
+1. **Subscribe to playlists** in TubeArchivist that you want to see in Plex
+2. **Subscribe to channels** in TubeArchivist for videos not in playlists
+3. **Ensure playlists are refreshed** in TubeArchivist so video associations are up-to-date
+4. **Scan your Plex library** after subscribing to playlists
+
+## Organization Examples
+
+- Video in subscribed playlist "Best of 2024" → Appears under "Best of 2024" playlist show
+- Video in subscribed channel "Tech Channel" (no playlists) → Appears under "Tech Channel" channel show
+- Video in 2 subscribed playlists → Appears in both playlist shows
+- Video in non-subscribed playlist, non-subscribed channel → Not shown in Plex
+
+## Notes
+
+- Episode ordering within playlists uses upload date (YYYYMMDD format)
+- The scanner uses caching to minimize API calls during library scans
 
 # Troubleshooting
 If you are having problems with seeing the Scanner or Agent, confirm that the instructions are followed.

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -765,35 +765,35 @@ def Scan(path, files, mediaList, subdirs):  # noqa: C901
                                             )
                                         )
 
-                                # If no subscribed playlists, fall back to channel
-                                if not shows_to_create:
-                                    channel_id = video_metadata.get("channel_id")
-                                    if channel_id:
-                                        try:
-                                            ch_metadata = get_ta_channel_metadata(channel_id)  # noqa: E501
-                                            if ch_metadata and ch_metadata.get("channel_subscribed"):  # noqa: E501
-                                                shows_to_create.append({
-                                                    "type": "channel",
-                                                    "show": video_metadata["show"],
-                                                    "metadata": ch_metadata
-                                                })
-                                                Log.info(
-                                                    "Video from subscribed channel: {}".format(  # noqa: E501
-                                                        video_metadata["channel_name"]
-                                                    )
-                                                )
-                                            else:
-                                                Log.info(
-                                                    "Video channel not subscribed, skipping: {}".format(  # noqa: E501
-                                                        video_metadata["channel_name"]
-                                                    )
-                                                )
-                                        except Exception as e:
-                                            Log.error(
-                                                "Error fetching channel metadata for {}: {}".format(  # noqa: E501
-                                                    channel_id, e
+                                # Also check if channel is subscribed (can appear in both playlist and channel)
+                                channel_id = video_metadata.get("channel_id")
+                                if channel_id:
+                                    try:
+                                        ch_metadata = get_ta_channel_metadata(channel_id)  # noqa: E501
+                                        if ch_metadata and ch_metadata.get("channel_subscribed"):  # noqa: E501
+                                            shows_to_create.append({
+                                                "type": "channel",
+                                                "show": video_metadata["show"],
+                                                "metadata": ch_metadata
+                                            })
+                                            Log.info(
+                                                "Video from subscribed channel: {}".format(  # noqa: E501
+                                                    video_metadata["channel_name"]
                                                 )
                                             )
+                                        elif not shows_to_create:
+                                            # Only log skip if not in any subscribed playlists
+                                            Log.info(
+                                                "Video channel not subscribed, skipping: {}".format(  # noqa: E501
+                                                    video_metadata["channel_name"]
+                                                )
+                                            )
+                                    except Exception as e:
+                                        Log.error(
+                                            "Error fetching channel metadata for {}: {}".format(  # noqa: E501
+                                                channel_id, e
+                                            )
+                                        )
 
                                 # Skip video if no subscribed playlists or channels
                                 if not shows_to_create:

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -47,6 +47,7 @@ PLEX_LIBRARY_URL = "http://localhost:32400/library/sections/"
 SOURCE = "TubeArchivist Scanner"
 TA_CONFIG = None
 LOG_RETENTION = 5
+METADATA_CACHE = {}  # Cache for playlist and channel metadata during scan
 
 
 SSL_CONTEXT = ssl.SSLContext(SSL_PROTOCOL)
@@ -488,6 +489,9 @@ def get_ta_video_metadata(ytid):
             )
             metadata["ytid"] = vid_response["youtube_id"]
             metadata["title"] = vid_response["title"]
+            metadata["channel_id"] = vid_response["channel"]["channel_id"]
+            metadata["channel_name"] = vid_response["channel"]["channel_name"]
+            metadata["playlist"] = vid_response.get("playlist", [])
             if TA_CONFIG["version"] < [0, 3, 7]:
                 Log.debug(
                     "Processing response with initial TA API response format."
@@ -547,6 +551,13 @@ def get_ta_channel_metadata(chid):
     if not chid:
         Log.error("No {} ID present.".format(mtype))
         return None
+
+    # Check cache first
+    cache_key = "channel_{}".format(chid)
+    if cache_key in METADATA_CACHE:
+        Log.debug("Using cached metadata for channel: {}".format(chid))
+        return METADATA_CACHE[cache_key]
+
     try:
         ch_response = get_ta_metadata(chid, mtype=mtype)
         Log.info(
@@ -565,6 +576,9 @@ def get_ta_channel_metadata(chid):
                 ch_response["channel_name"],
                 ch_response["channel_id"],
             )
+            metadata["channel_id"] = ch_response["channel_id"]
+            metadata["channel_name"] = ch_response["channel_name"]
+            metadata["channel_subscribed"] = ch_response["channel_subscribed"]
             if TA_CONFIG["version"] < [0, 3, 7]:
                 Log.debug(
                     "Processing response with initial TA API response format."
@@ -585,6 +599,78 @@ def get_ta_channel_metadata(chid):
             metadata["banner_url"] = ch_response["channel_banner_url"]
             metadata["thumb_url"] = ch_response["channel_thumb_url"]
             metadata["tvart_url"] = ch_response["channel_tvart_url"]
+            # Cache the result
+            METADATA_CACHE[cache_key] = metadata
+            return metadata
+        else:
+            Log.error(
+                "Empty response returned from %s when requesting data about %s."  # noqa: E501
+                % (TA_CONFIG["ta_url"], mtype)
+            )
+    except Exception as e:
+        Log.error(
+            "Error processing %s response from TubeArchivist at location '%s', Exception: '%s'"  # noqa: E501
+            % (mtype, TA_CONFIG["ta_url"], e)
+        )
+        raise e
+
+
+def get_ta_playlist_metadata(plid):
+    mtype = "playlist"
+    if not TA_CONFIG:
+        Log.error("No configurations in TA_CONFIG.")
+        return None
+    if not plid:
+        Log.error("No {} ID present.".format(mtype))
+        return None
+
+    # Check cache first
+    cache_key = "playlist_{}".format(plid)
+    if cache_key in METADATA_CACHE:
+        Log.debug("Using cached metadata for playlist: {}".format(plid))
+        return METADATA_CACHE[cache_key]
+
+    try:
+        pl_response = get_ta_metadata(plid, mtype=mtype)
+        Log.info(
+            "Response from TubeArchivist received for YouTube {}: {}".format(
+                mtype, plid
+            )
+        )
+        if pl_response:
+            if TA_CONFIG["version"] < [0, 5, 0]:
+                Log.debug(
+                    "Processing response with pre-v0.5.0 TA API response format."  # noqa: E501
+                )
+                pl_response = pl_response["data"]
+            metadata = {}
+            metadata["show"] = "{} [{}]".format(
+                pl_response["playlist_name"],
+                pl_response["playlist_id"],
+            )
+            metadata["playlist_id"] = pl_response["playlist_id"]
+            metadata["playlist_name"] = pl_response["playlist_name"]
+            metadata["playlist_subscribed"] = pl_response["playlist_subscribed"]
+            if TA_CONFIG["version"] < [0, 3, 7]:
+                Log.debug(
+                    "Processing response with initial TA API response format."
+                )
+                playlist_refresh = datetime.datetime.strptime(
+                    pl_response["playlist_last_refresh"], "%d %b, %Y"
+                )
+            elif TA_CONFIG["version"] < [0, 5, 3]:
+                playlist_refresh = datetime.datetime.strptime(
+                    pl_response["playlist_last_refresh"], "%Y-%m-%d"
+                )
+            else:
+                playlist_refresh = set_date_to_utc(
+                    pl_response["playlist_last_refresh"]
+                )
+            metadata["refresh_date"] = playlist_refresh.strftime("%Y%m%d")
+            metadata["description"] = pl_response["playlist_description"]
+            metadata["thumb_url"] = pl_response["playlist_thumbnail"]
+            # Cache the result
+            METADATA_CACHE[cache_key] = metadata
             return metadata
         else:
             Log.error(
@@ -605,6 +691,12 @@ def Scan(path, files, mediaList, subdirs):  # noqa: C901
     TA_CONFIG["online"] = None
     TA_CONFIG["version"] = []
     TA_CONFIG["online"], TA_CONFIG["version"] = test_ta_connection()
+
+    # Clear metadata cache at start of each scan
+    global METADATA_CACHE
+    METADATA_CACHE = {}
+    Log.info("Metadata cache cleared for new scan")
+
     Log.info("Initiating scan of library files...")
     VideoFiles.Scan(path, files, mediaList, subdirs)
 
@@ -646,7 +738,73 @@ def Scan(path, files, mediaList, subdirs):  # noqa: C901
                                 ytid = file
                             try:
                                 video_metadata = get_ta_video_metadata(ytid)
-                                show = video_metadata["show"]
+
+                                # Determine which shows to create based on subscription status
+                                shows_to_create = []
+
+                                # Check for subscribed playlists first
+                                playlist_ids = video_metadata.get("playlist", [])
+                                for playlist_id in playlist_ids:
+                                    try:
+                                        pl_metadata = get_ta_playlist_metadata(playlist_id)  # noqa: E501
+                                        if pl_metadata and pl_metadata.get("playlist_subscribed"):  # noqa: E501
+                                            shows_to_create.append({
+                                                "type": "playlist",
+                                                "show": pl_metadata["show"],
+                                                "metadata": pl_metadata
+                                            })
+                                            Log.info(
+                                                "Video belongs to subscribed playlist: {}".format(  # noqa: E501
+                                                    pl_metadata["playlist_name"]
+                                                )
+                                            )
+                                    except Exception as e:
+                                        Log.error(
+                                            "Error fetching playlist metadata for {}: {}".format(  # noqa: E501
+                                                playlist_id, e
+                                            )
+                                        )
+
+                                # If no subscribed playlists, fall back to channel
+                                if not shows_to_create:
+                                    channel_id = video_metadata.get("channel_id")
+                                    if channel_id:
+                                        try:
+                                            ch_metadata = get_ta_channel_metadata(channel_id)  # noqa: E501
+                                            if ch_metadata and ch_metadata.get("channel_subscribed"):  # noqa: E501
+                                                shows_to_create.append({
+                                                    "type": "channel",
+                                                    "show": video_metadata["show"],
+                                                    "metadata": ch_metadata
+                                                })
+                                                Log.info(
+                                                    "Video from subscribed channel: {}".format(  # noqa: E501
+                                                        video_metadata["channel_name"]
+                                                    )
+                                                )
+                                            else:
+                                                Log.info(
+                                                    "Video channel not subscribed, skipping: {}".format(  # noqa: E501
+                                                        video_metadata["channel_name"]
+                                                    )
+                                                )
+                                        except Exception as e:
+                                            Log.error(
+                                                "Error fetching channel metadata for {}: {}".format(  # noqa: E501
+                                                    channel_id, e
+                                                )
+                                            )
+
+                                # Skip video if no subscribed playlists or channels
+                                if not shows_to_create:
+                                    Log.info(
+                                        "Skipping video '{}' - no subscribed playlists or channels".format(  # noqa: E501
+                                            video_metadata["title"]
+                                        )
+                                    )
+                                    continue
+
+                                # Process common metadata
                                 if "video" in video_metadata["type"]:
                                     title = video_metadata["title"]
                                     season = video_metadata["season"]
@@ -656,7 +814,56 @@ def Scan(path, files, mediaList, subdirs):  # noqa: C901
                                         video_metadata["title"],
                                     )
                                     season = 0
-                                episode = video_metadata["episode"]
+                                episode_base = video_metadata["episode"]
+
+                                # Create Media.Episode for each show (playlist or channel)
+                                for show_info in shows_to_create:
+                                    show = show_info["show"]
+
+                                    # Track episode counts per show
+                                    if show not in episode_counts:
+                                        episode_counts[show] = {}
+                                    if season not in episode_counts[show]:
+                                        episode_counts[show][season] = {}
+                                    if episode_base not in episode_counts[show][season]:  # noqa: E501
+                                        episode_counts[show][season][episode_base] = 0
+                                    episode_counts[show][season][episode_base] += 1
+                                    episode = "{}{:02d}".format(
+                                        str(episode_base[2:]),
+                                        episode_counts[show][season][episode_base],
+                                    )
+
+                                    tv_show = Media.Episode(
+                                        str(show).encode("UTF-8"),
+                                        str(season).encode("UTF-8"),
+                                        episode,
+                                        str(title).encode("UTF-8"),
+                                        str(season).encode("UTF-8"),
+                                    )
+                                    Log.info(
+                                        "Identified episode '{} - {}' with TV Show {} ({}) under Season {}.".format(  # noqa: E501
+                                            episode, title, show, show_info["type"], season  # noqa: E501
+                                        )
+                                    )
+                                    episode_split = [
+                                        str(episode[x : x + 2])  # noqa: E203
+                                        for x in range(0, len(episode), 2)
+                                    ]
+                                    tv_show.released_at = str(
+                                        "{}-{}-{}".format(
+                                            episode_split[0],
+                                            episode_split[1],
+                                            episode_split[2],
+                                        )
+                                    ).encode("UTF-8")
+                                    tv_show.parts.append(i)
+                                    Log.info(
+                                        "Adding episode '{}' to TV show '{}' list of episodes.".format(  # noqa: E501
+                                            episode, show
+                                        )
+                                    )
+                                    mediaList.append(tv_show)
+
                             except Exception as e:
                                 Log.error(
                                     "Issue with fetching or setting metadata from video using response metadata: '%s', Exception: '%s'"  # noqa: E501
@@ -669,48 +876,6 @@ def Scan(path, files, mediaList, subdirs):  # noqa: C901
                             )
                             break
 
-                        if show not in episode_counts:
-                            episode_counts[show] = {}
-                        if season not in episode_counts[show]:
-                            episode_counts[show][season] = {}
-                        if episode not in episode_counts[show][season]:
-                            episode_counts[show][season][episode] = 0
-                        episode_counts[show][season][episode] += 1
-                        episode = "{}{:02d}".format(
-                            str(episode[2:]),
-                            episode_counts[show][season][episode],
-                        )
-
-                        tv_show = Media.Episode(
-                            str(show).encode("UTF-8"),
-                            str(season).encode("UTF-8"),
-                            episode,
-                            str(title).encode("UTF-8"),
-                            str(season).encode("UTF-8"),
-                        )
-                        Log.info(
-                            "Identified episode '{} - {}' with TV Show {} under Season {}.".format(  # noqa: E501
-                                episode, title, show, season
-                            )
-                        )
-                        episode_split = [
-                            str(episode[x : x + 2])  # noqa: E203
-                            for x in range(0, len(episode), 2)
-                        ]
-                        tv_show.released_at = str(
-                            "{}-{}-{}".format(
-                                episode_split[0],
-                                episode_split[1],
-                                episode_split[2],
-                            )
-                        ).encode("UTF-8")
-                        tv_show.parts.append(i)
-                        Log.info(
-                            "Adding episode '{}' to TV show '{}' list of episodes.".format(  # noqa: E501
-                                episode, show
-                            )
-                        )
-                        mediaList.append(tv_show)
                         break
 
     Stack.Scan(path, files, mediaList, subdirs)


### PR DESCRIPTION
## Summary

This PR adds support for organizing videos by TubeArchivist playlists in Plex, with subscription-based filtering. Videos now appear under their subscribed playlists instead of being scattered across individual channel shows.

<img width="400" alt="After" src="https://github.com/user-attachments/assets/2795b556-eef6-46c0-916e-d705f871cf94" />
<img width="400" alt="Before" src="https://github.com/user-attachments/assets/c6f13659-3124-4379-8b68-cf30ae76f256" />

## Changes

### Scanner (`Scanners/Series/TubeArchivist Series Scanner.py`)
- Added `get_ta_playlist_metadata()` function to fetch playlist metadata from TubeArchivist API
- Enhanced `get_ta_video_metadata()` to include `channel_id`, `channel_name`, and `playlist` fields
- Enhanced `get_ta_channel_metadata()` to include `channel_subscribed` status
- Implemented subscription-aware organization logic:
  - Checks videos for subscribed playlists first
  - Creates Media.Episode entries for each subscribed playlist
  - Falls back to channel organization if no subscribed playlists found
  - **Skips videos that don't belong to any subscribed playlists or channels**
- Added metadata caching to minimize duplicate API calls during library scans

### Agent (`Contents/Code/__init__.py`)
- Added `get_ta_playlist_metadata()` function to fetch playlist metadata for agent
- Implemented GUID type detection to differentiate between playlist IDs (PL prefix) and channel IDs (UC/UU prefix)
- Updated `Search()` function with unified show IDs for playlists to prevent fragmentation across channel folders
- Updated `Update()` function to handle both playlist and channel GUIDs
- Added conditional handling for channel-specific metadata fields (tvart, banner)

### Documentation (`README.md`)
- Updated limitations section to reflect playlist support is now available
- Added comprehensive "Playlist Support" section explaining:
  - How subscription-aware organization works
  - Setup requirements
  - Organization examples
  - Implementation notes

## Behavior

### Organization Logic
1. Videos in subscribed playlists appear under those playlist shows
2. Videos from subscribed channels also appear under their channel show
3. Videos can appear in BOTH playlists and channels if both are subscribed
4. Videos with no subscribed playlists or channels are filtered out

### Multi-Playlist Support
Videos belonging to multiple subscribed playlists will appear in each playlist show (duplicate entries by design).

### Backward Compatibility
Existing channel-only videos continue to work as before. The subscription filtering only applies when playlist/channel subscription data is available.

## Performance

Metadata caching reduces duplicate API calls during scans. Cache is cleared at the start of each scan to ensure fresh subscription data.
