### PR TITLE
Fix episode thumbnails returning invalid URI on Windows

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -42,7 +42,7 @@ CachePath = os.path.join(
     PLEX_ROOT,
     "Plug-in Support",
     "Data",
-    "com.plexapp.agents.tubearchivist-agent",
+    "com.plexapp.agents.tubearchivist_agent",
     "DataItems",
 )
 PLEX_LIBRARY = {}

--- a/Scanners/Series/TubeArchivist Series Scanner.py
+++ b/Scanners/Series/TubeArchivist Series Scanner.py
@@ -676,9 +676,10 @@ def Scan(path, files, mediaList, subdirs):  # noqa: C901
                         if episode not in episode_counts[show][season]:
                             episode_counts[show][season][episode] = 0
                         episode_counts[show][season][episode] += 1
+                        episode_date = episode  # Preserve YYYYMMDD
                         episode = "{}{:02d}".format(
-                            str(episode[2:]),
-                            episode_counts[show][season][episode],
+                            str(episode[4:]),
+                            episode_counts[show][season][episode_date],
                         )
 
                         tv_show = Media.Episode(
@@ -693,15 +694,11 @@ def Scan(path, files, mediaList, subdirs):  # noqa: C901
                                 episode, title, show, season
                             )
                         )
-                        episode_split = [
-                            str(episode[x : x + 2])  # noqa: E203
-                            for x in range(0, len(episode), 2)
-                        ]
                         tv_show.released_at = str(
                             "{}-{}-{}".format(
-                                episode_split[0],
-                                episode_split[1],
-                                episode_split[2],
+                                episode_date[2:4],
+                                episode_date[4:6],
+                                episode_date[6:8],
                             )
                         ).encode("UTF-8")
                         tv_show.parts.append(i)


### PR DESCRIPTION
Fixes #98

The Plex Photo Transcoder on Windows fails with `GetPathFromUri: invalid uri` when resolving episode thumbnail paths. The issue is that the internal metadata path ends up too long — the episode number format combined with the agent identifier creates paths right at the edge of what Plex can handle.

The scanner was stripping only the century from the episode date (`episode[2:]`), which left 8-digit episode numbers for anything 2010 and later. Since the year is already stored in the season, this changes it to strip the full year (`episode[4:]`), bringing episode numbers down to 6 digits and keeping paths short enough for the Photo Transcoder to resolve.

The `released_at` date is now computed from the original date string directly instead of being reconstructed from the shortened episode number.

Also fixes a pre-existing mismatch where `CachePath` in the agent used a hyphen (`tubearchivist-agent`) instead of matching the actual `CFBundleIdentifier` underscore (`tubearchivist_agent`).

**Note:** This is a breaking change — existing libraries will need a full rescan.

I ran this on Windows 11, version 24H2. Plex Version 1.112.0.359-0d79a49f